### PR TITLE
gofmt and makefile to build binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .sass-cache
+.vscode
 
 # Build artifacts
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .DS_Store
 .sass-cache
+
+# Build artifacts
 /build
+/dist
+
 node_modules
 videos
-buildinfo.go
 bindata.go
 LOCAL_NOTES.txt

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,8 @@ bindata:
 ## Build UI
 ui:
 	cd ui/src && npm run build && cd -
+
+.PHONY: run
+## Run the server
+run:
+	DEBUG=true go run *.go serve /tmp/videos

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+VERSION := v0.3.3
+NAME := gohls
+BUILDSTRING := $(shell git log --pretty=format:'%h' -n 1)
+VERSIONSTRING := $(NAME) version $(VERSION)+$(BUILDSTRING)
+
+detected_OS := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+ifeq ($(detected_OS),Darwin)
+    BUILDDATE := $(shell date -u  +%Y-%m-%d)
+else
+	BUILDDATE := $(shell date -u -Iseconds)
+endif
+
+OUTPUT = dist/$(NAME)-$(shell dpkg --print-architecture)-$(shell uname -s | awk '{print tolower($$0)}')
+LDFLAGS := "-X \"main.VERSION=$(VERSIONSTRING)\" -X \"main.BUILDDATE=$(BUILDDATE)\""
+
+default: build
+
+.PHONY: build
+## Build a development binary
+build: $(OUTPUT)
+
+$(OUTPUT): *.go
+	@mkdir -p dist/
+	go build -o $(OUTPUT) -ldflags=$(LDFLAGS)
+
+.PHONY: build_release
+## Build the release binaries and save them to ./dist
+build_release: clean
+	gox -arch="amd64" -os="windows darwin linux" -output="dist/$(NAME)-{{.Arch}}-{{.OS}}" -ldflags=$(LDFLAGS)
+
+.PHONY: clean
+## Remove the release folder
+clean:
+	rm -rf dist/
+
+.PHONY: tag
+## Tag the project with the current version and push to GitHub
+tag:
+	git tag $(VERSION)
+	git push origin --tags
+
+## Compress the binaries
+upx:
+	cd dist/ && upx *
+
+## Create artifacts
+bindata:
+	go-bindata -prefix ui/build ui/build/...
+
+.PHONY: ui
+## Build UI
+ui:
+	cd ui/src && npm run build && cd -

--- a/Makefile
+++ b/Makefile
@@ -17,21 +17,21 @@ default: build
 
 .PHONY: build
 ## Build a development binary
-build: $(OUTPUT)
-
-$(OUTPUT): *.go
+build:
 	@mkdir -p dist/
 	go build -o $(OUTPUT) -ldflags=$(LDFLAGS)
 
 .PHONY: build_release
 ## Build the release binaries and save them to ./dist
-build_release: clean
+build_release: clean ui bindata
 	gox -arch="amd64" -os="windows darwin linux" -output="dist/$(NAME)-{{.Arch}}-{{.OS}}" -ldflags=$(LDFLAGS)
 
 .PHONY: clean
 ## Remove the release folder
 clean:
 	rm -rf dist/
+	rm -rf ui/build
+	rm -rf bindata.go
 
 .PHONY: tag
 ## Tag the project with the current version and push to GitHub

--- a/buildinfo.go
+++ b/buildinfo.go
@@ -1,0 +1,8 @@
+package main
+
+var (
+  // VERSION is set by the makefile
+  VERSION = "VERSION"
+  // BUILDDATE is set by the makefile
+  BUILDDATE = "BUILDDATE"
+)

--- a/buildinfo.go.in
+++ b/buildinfo.go.in
@@ -1,5 +1,0 @@
-package main
-
-const VERSION = "##VERSION##"
-const COMMIT = "##COMMIT##"
-const BUILD_TIME = "##BUILD_TIME##"

--- a/cmd_clear_cache.go
+++ b/cmd_clear_cache.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+
 	"github.com/google/subcommands"
 	"github.com/shimberger/gohls/hls"
 )

--- a/cmd_serve.go
+++ b/cmd_serve.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
+
 	"github.com/google/subcommands"
 	"github.com/shimberger/gohls/hls"
-	"net/http"
 )
 
 type serveCmd struct {

--- a/cmd_version.go
+++ b/cmd_version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
 	"github.com/google/subcommands"
 )
 
@@ -20,6 +21,6 @@ func (*versionCmd) Usage() string {
 func (p *versionCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	fmt.Printf("gohls %v (commit %v) (from %v)\n", VERSION, COMMIT, BUILD_TIME)
+	fmt.Printf("%s (from %s)\n", VERSION, BUILDDATE)
 	return subcommands.ExitSuccess
 }

--- a/http_debug.go
+++ b/http_debug.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"net/http"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type DebugHandlerWrapper struct {

--- a/http_singleasset.go
+++ b/http_singleasset.go
@@ -3,30 +3,34 @@ package main
 import (
 	"bytes"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"io"
 	"mime"
 	"net/http"
 	"path"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 )
 
-type singleAssetHandler struct {
+// SingleAssetHandler handles an asset in a path
+type SingleAssetHandler struct {
 	path string
 }
 
-func NewSingleAssetHandler(path string) *singleAssetHandler {
-	return &singleAssetHandler{path}
+// NewSingleAssetHandler returns an asset handler
+func NewSingleAssetHandler(path string) *SingleAssetHandler {
+	return &SingleAssetHandler{path}
 }
 
-func (s *singleAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *SingleAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	data, err := Asset(strings.TrimLeft(r.URL.Path, "/"))
 	if err != nil {
 		log.Debugf("SPA HTTP handling fallback")
-		data, err := Asset(s.path)
+		data, err = Asset(s.path)
 		if err != nil {
 			http.NotFound(w, r)
 			fmt.Fprintf(w, "Not found %v", s.path)
+			return
 		}
 		w.Header().Set("Content-Type", mime.TypeByExtension(path.Ext(s.path)))
 		io.Copy(w, bytes.NewBuffer(data))

--- a/init.go
+++ b/init.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/shimberger/gohls/hls"
 	"os"
 	"os/exec"
 	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/shimberger/gohls/hls"
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/google/subcommands"
 	"os"
+
+	"github.com/google/subcommands"
 )
 
 func main() {

--- a/set_homedir.go
+++ b/set_homedir.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
+	"path"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/shimberger/gohls/hls"
-	"path"
 )
 
 func setVideoDir(f *flag.FlagSet) string {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4401,12 +4401,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4421,17 +4423,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4548,7 +4553,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4560,6 +4566,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4574,6 +4581,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4581,12 +4589,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4605,6 +4615,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4685,7 +4696,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4697,6 +4709,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4818,6 +4831,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
- Minor cleanup using gofmt
- Added a Makefile to build binaries, UI and assets. No snapshot packets are created.

The Makefile allows me to do individual make steps without running the full build procedure

Limitations
- `make` doesn't pass through arguments, so no subcommands possible