### PR TITLE
fix go.rice usage bug

### DIFF
--- a/internal/api/handle_singleasset.go
+++ b/internal/api/handle_singleasset.go
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var staticBox = rice.MustFindBox("../../ui/build")
+var staticBox *rice.Box
 
 type singleAssetHandler struct {
 	path string
@@ -23,7 +23,14 @@ func NewSingleAssetHandler(path string) *singleAssetHandler {
 	return &singleAssetHandler{path}
 }
 
+func initStaticBox() {
+	if staticBox == nil {
+		staticBox = rice.MustFindBox("../../ui/build")
+	}
+}
+
 func (s *singleAssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	initStaticBox()
 	data, err := staticBox.Bytes(strings.TrimLeft(r.URL.Path, "/"))
 	if err != nil {
 		log.Debugf("SPA HTTP handling fallback")


### PR DESCRIPTION
I found embed model of go.rice is not working. Then I write a test code to debug, the reason is `var staticBox = rice.MustFindBox("../../ui/build")` in `internal/api/handle_singleasset.go`. `MustFindBox()` should check variable `rice.embedded.EmbeddedBoxes`, and the latter is initialized in `init()` function in `rice-box.go`, which is generated by go.rice. But the initialization  of `staticBox` precedes the execution of the function `init()`, so that `staticBox` cannot get right value.

I move the initialization  of `staticBox` to a normal function, to solve the problem.