### PR TITLE
fix unsort filelist bug

### DIFF
--- a/internal/fileindex/index.go
+++ b/internal/fileindex/index.go
@@ -44,3 +44,17 @@ func (e *entry) Path() string {
 func (e *entry) ParentId() string {
 	return e.parentId
 }
+
+type Entries []Entry
+
+func (es Entries) Len() int {
+	return len(es)
+}
+
+func (es Entries) Less(i, j int) bool {
+	return es[i].Name() < es[j].Name()
+}
+
+func (es Entries) Swap(i, j int) {
+	es[i], es[j] = es[j], es[i]
+}

--- a/internal/fileindex/index_compound.go
+++ b/internal/fileindex/index_compound.go
@@ -2,6 +2,7 @@ package fileindex
 
 import (
 	"fmt"
+	"sort"
 )
 
 type compound struct {
@@ -106,6 +107,7 @@ func (i *compound) List(parent string) ([]Entry, error) {
 	for j, e := range list {
 		list[j] = i.transform(idx, e)
 	}
+	sort.Sort(Entries(list))
 	return list, nil
 }
 


### PR DESCRIPTION
After adding prev&next button, I found the video file list is unsorted. Add `sort.Sort()` before return from `compound.List()` to fix it.