### PR TITLE
explicit aac encoding settings

### DIFF
--- a/internal/hls/segment.go
+++ b/internal/hls/segment.go
@@ -58,7 +58,9 @@ func EncodingArgs(videoFile string, segment int64, res int64) []string {
 		"-preset", "veryfast",
 
 		// aac audio codec
-		"-acodec", "aac",
+		"-c:a", "aac",
+		"-b:a", "128k",
+		"-ac", "2",
 		//
 		"-pix_fmt", "yuv420p",
 


### PR DESCRIPTION
Howdy,

this should fix https://github.com/shimberger/gohls/issues/61

To sum up, I set those AAC audio encoding settings more explicitely following https://www.martin-riedl.de/2018/08/24/using-ffmpeg-as-a-hls-streaming-server-part-1/ guide.

Now all of my tested files are working properly.

Best regards
midzer