### PR TITLE
persistent log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,14 @@ buildinfo.go
 rice-box.go
 LOCAL_NOTES.txt
 gohls-config.json
+
+# ignore logfiles
+/logs/
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+gohls

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/shimberger/gohls
 go 1.14
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/GeertJohan/go.rice v1.0.0
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
@@ -12,4 +13,6 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95 // indirect
 	golang.org/x/text v0.3.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GeertJohan/go.incremental v1.0.0 h1:7AH+pY1XUgQE4Y1HcXYaMqAI0m9yrFqo/jt0CW30vsg=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
 github.com/GeertJohan/go.rice v1.0.0 h1:KkI6O9uMaQU3VEKaj01ulavtF7o1fWT7+pk/4voiMLQ=
@@ -43,3 +45,6 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTu
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/cmd/init_hls.go
+++ b/internal/cmd/init_hls.go
@@ -4,22 +4,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 
 	"github.com/shimberger/gohls/internal/hls"
 	log "github.com/sirupsen/logrus"
 )
 
 func init_hls(dataDir string) {
-	log.SetOutput(os.Stderr)
-	log.SetLevel(log.InfoLevel)
-	if _, err := strconv.ParseBool(os.Getenv("DEBUG")); err == nil {
-		log.SetLevel(log.DebugLevel)
-	}
-	if _, err := strconv.ParseBool(os.Getenv("TRACE")); err == nil {
-		log.SetLevel(log.TraceLevel)
-	}
-
 	// Find ffmpeg
 	ffmpeg, err := exec.LookPath("ffmpeg")
 	if err != nil {

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/shimberger/gohls/internal/api"
 	"github.com/shimberger/gohls/internal/config"
 	"github.com/shimberger/gohls/internal/hls"
+	_ "github.com/shimberger/gohls/internal/logger"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -35,13 +35,13 @@ var serveCmd = &cobra.Command{
 		api.Setup(config)
 
 		// Dump information to user
-		fmt.Printf("Path to ffmpeg executable: %v\n", hls.FFMPEGPath)
-		fmt.Printf("Path to ffprobe executable: %v\n", hls.FFProbePath)
-		fmt.Printf("HLS data directory: %v/\n", hls.HomeDir)
-		fmt.Printf("Visit http://%v/\n", listen)
+		log.Infof("Path to ffmpeg executable: %v\n", hls.FFMPEGPath)
+		log.Infof("Path to ffprobe executable: %v\n", hls.FFProbePath)
+		log.Infof("HLS data directory: %v/\n", hls.HomeDir)
+		log.Infof("Visit http://%v/\n", listen)
 
 		if herr := http.ListenAndServe(listen, nil); herr != nil {
-			fmt.Printf("Error listening %v", herr)
+			log.Infof("Error listening %v", herr)
 		}
 
 	},

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,36 @@
+package logger
+
+import (
+	"io"
+	"os"
+	"strconv"
+
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+const timestampFormat = "2006-01-02 15:04:05.001 -0700 MST"
+
+func init() {
+	multiWriter := io.MultiWriter(os.Stderr, &lumberjack.Logger{
+		Filename:   "logs/server.log", // Filename is the file to write logs to.  Backup log files will be retained in the same directory.
+		MaxSize:    50,                // MaxSize is the maximum size in megabytes of the log file before it gets rotated
+		MaxBackups: 5,                 // MaxBackups is the maximum number of old log files to retain.
+		MaxAge:     30,                // MaxAge is the maximum number of days to retain old log files based on the timestamp encoded in their filename.
+	})
+	log.SetOutput(multiWriter)
+
+	log.SetLevel(log.InfoLevel)
+	if _, err := strconv.ParseBool(os.Getenv("DEBUG")); err == nil {
+		log.SetLevel(log.DebugLevel)
+	}
+	if _, err := strconv.ParseBool(os.Getenv("TRACE")); err == nil {
+		log.SetLevel(log.TraceLevel)
+	}
+
+	dateFormatter := &log.JSONFormatter{
+		TimestampFormat: timestampFormat,
+	}
+	// output in JSON format
+	log.SetFormatter(dateFormatter)
+}


### PR DESCRIPTION
Hi shimberger：

maybe we can persistent log for later debuging. so I use `gopkg.in/natefinch/lumberjack.v2` to persistent logfile, **default is `logs/server.log`**

and the log format change a bit

logformat before:
```sh
time="2020-12-07T16:01:22+08:00" level=info msg="Initializing HLS with directory '.gohls-data'"
time="2020-12-07T16:01:22+08:00" level=info msg="Starting index scan for filepath.MemIndex(d:\\videos)"
Path to ffmpeg executable: D:\Chrome\ffmpeg-4.2.3-win64-static\bin\ffmpeg.exe
Path to ffprobe executable: D:\Chrome\ffmpeg-4.2.3-win64-static\bin\ffprobe.exe
HLS data directory: .gohls-data/
Visit http://127.0.0.1:8080/
time="2020-12-07T16:01:22+08:00" level=info msg="Finished index scan for filepath.MemIndex(d:\\videos). Found 7 entries"
time="2020-12-07T16:01:23+08:00" level=warning msg="Error moving cache file into place: rename .gohls\\cache\\segments\\e9fa4f01c7f76999b2d5e80a182bcc9c1d85ec41.040692011 .gohls\\cache\\segments\\e9fa4f01c7f76999b2d5e80a182bcc9c1d85ec41: The process cannot access the file because it is being used by another process."
```

logformat now:
```sh
{"level":"info","msg":"Initializing HLS with directory '.gohls-data'","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"Starting index scan for filepath.MemIndex(D:\\firefox)","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"Path to ffmpeg executable: D:\\Chrome\\ffmpeg-4.2.3-win64-static\\bin\\ffmpeg.exe\n","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"Path to ffprobe executable: D:\\Chrome\\ffmpeg-4.2.3-win64-static\\bin\\ffprobe.exe\n","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"HLS data directory: .gohls-data/\n","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"Visit http://127.0.0.1:8080/\n","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"Starting index scan for filepath.MemIndex(D:\\videos)","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"Finished index scan for filepath.MemIndex(D:\\videos). Found 7 entries","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"info","msg":"Finished index scan for filepath.MemIndex(D:\\firefox). Found 39 entries","time":"2020-12-07 16:20:01.012 +0800 CST"}
{"level":"warning","msg":"Error moving cache file into place: rename .gohls\\cache\\segments\\9a28f72d24326cf307a22796b4948d5825fedb6d.588033891 .gohls\\cache\\segments\\9a28f72d24326cf307a22796b4948d5825fedb6d: The process cannot access the file because it is being used by another process.","time":"2020-12-07 16:20:02.012 +0800 CST"}
```               

in `internal/logger/logger.go`, we config the log setttings in `init()` method, and in `internal/cmd/serve.go`, we import `	_ "github.com/shimberger/gohls/internal/logger"` make `init()` called, so in the whole project, when we use `logrus` print info, the setting of `logrus` will be applied
